### PR TITLE
✨ Add a warning to Rocket's installer

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+COLOR_RESET="$(tput sgr0)"
+COLOR_YELLOW="$(tput setaf 3)"
+
 mkdir -p ~/.local/share/icons/hicolor/scalable
 cp rocket.svg ~/.local/share/icons/hicolor/scalable/
 chmod +x rocket
@@ -9,3 +12,6 @@ chmod +x rocket.desktop
 cp rocket.desktop ~/.local/share/applications/
 mkdir ~/.config/rocket
 cp wallpaper.jpeg ~/.config/rocket
+
+echo "Rocket is installed now."
+echo "${COLOR_YELLOW}warning${COLOR_RESET}: be sure to add '$HOME/.local/bin' to your PATH to be able to run Rocket."


### PR DESCRIPTION
Users should now be notified to add ~/.local/bin to their PATH, in case they haven't already.